### PR TITLE
Run locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
 # some specific files we don't want in the repo
+local_config.yaml
+local_overrides.yaml
+local_augments.yaml
+tests/local_config.yaml
+tests/local_overrides.yaml
+tests/local_augments.yaml
 data/DECam_examples/c4d_221104_074232_ori.fits.fz
 
 # Byte-compiled / optimized / DLL files

--- a/README.md
+++ b/README.md
@@ -130,12 +130,12 @@ Database migrations are handled with alembic.
 
 If you've just created a database and want to initialize it with all the tables, run
 ```
-  SEECHANGE_CONFIG=<configfile> alembic upgrade head
+  alembic upgrade head
 ```
 
 After editing any schema, you have to create new database migrations to apply them.  Do this by running something like:
 ```
-  SEECHANGE_CONFIG=<configfile> alembic revision --autogenerate -m "<put a short comment here>"
+  alembic revision --autogenerate -m "<put a short comment here>"
 ```
 The comment will go in the filename, so it should really be short.  
 Look out for any warnings, and review the created migration file before applying it (with `alembic upgrade head`).

--- a/default_config.yaml
+++ b/default_config.yaml
@@ -1,8 +1,10 @@
+overrides:
+  - local_config.yaml
+
 path:
   data_root: null
   data_temp: null
-  server_data: null
-  # TODO: need to add additional options for server communications
+
 db:
   engine: postgresql
   user: postgres

--- a/devshell/docker-compose.yaml
+++ b/devshell/docker-compose.yaml
@@ -16,8 +16,6 @@ services:
   seechange_dbmigrate:
     image: gchr.io/${GITHUB_REPOSITORY_OWNER}/seechange
     build: ../docker/application
-    environment:
-      SEECHANGE_CONFIG: /seechange/devshell/seechange_devshell.yaml
     depends_on:
       seechange_postgres:
          condition: service_healthy
@@ -32,8 +30,6 @@ services:
 seechange:
     image: gchr.io/${GITHUB_REPOSITORY_OWNER}/seechange
     build: ../docker/application
-    environment:
-      SEECHANGE_CONFIG: /seechange/devshell/seechange_devshell.yaml
     depends_on:
       seechange_postgres:
          condition: service_healthy

--- a/models/base.py
+++ b/models/base.py
@@ -237,8 +237,21 @@ class SeeChangeBase:
 
 Base = declarative_base(cls=SeeChangeBase)
 
+ARCHIVE = None
 
-class FileOnDiskMixin:
+
+def get_archive_object():
+    """Return a global archive object. If it doesn't exist, create it based on the current config. """
+    global ARCHIVE
+    if ARCHIVE is None:
+        cfg = config.Config.get()
+        archive_specs = cfg.value('archive', None)
+        if archive_specs is not None:
+            ARCHIVE = Archive(**archive_specs)
+    return ARCHIVE
+
+
+class FileOnDiskMixin():
     """Mixin for objects that refer to files on disk.
 
     Files are assumed to live on the local disk (underneath the
@@ -315,15 +328,6 @@ class FileOnDiskMixin:
     if not os.path.isdir(local_path):
         os.makedirs(local_path, exist_ok=True)
 
-    archive = cfg.value('archive', None)
-    if archive is not None:
-        archive = Archive( archive_url=cfg.value('archive.url'),
-                           path_base=cfg.value('archive.path_base'),
-                           token=cfg.value('archive.token'),
-                           verify_cert=cfg.value('archive.verify_cert'),
-                           local_read_dir=cfg.value('archive.read_dir'),
-                           local_write_dir=cfg.value('archive.write_dir') )
-        
     @classmethod
     def safe_mkdir(cls, path):
         if path is None or path == '':
@@ -426,9 +430,22 @@ class FileOnDiskMixin:
         self.filepath = kwargs.pop('filepath', self.filepath)
         self.nofile = kwargs.pop('nofile', self._do_not_require_file_to_exist())
 
+        self._archive = None
+
     @orm.reconstructor
     def init_on_load(self):
         self.nofile = self._do_not_require_file_to_exist()
+        self._archive = None
+
+    @property
+    def archive(self):
+        if self._archive is None:
+            self._archive = get_archive_object()
+        return self._archive
+
+    @archive.setter
+    def archive(self, value):
+        self._archive = value
 
     @staticmethod
     def _do_not_require_file_to_exist():

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -77,8 +77,7 @@ services:
     build:
       context: ../docker/application
     environment:
-      SEECHANGE_CONFIG: /seechange/tests/seechange_config_test.yaml
-      ARCHIVE_DIR: /archive_storage/base
+      SEECHANGE_TEST_ARCHIVE_DIR: /archive_storage/base
     depends_on:
       setuptables:
         condition: service_completed_successfully
@@ -100,8 +99,7 @@ services:
     build:
       context: ../docker/application
     environment:
-      SEECHANGE_CONFIG: /seechange/tests/seechange_config_test.yaml
-      ARCHIVE_DIR: /archive_storage/base
+      SEECHANGE_TEST_ARCHIVE_DIR: /archive_storage/base
     depends_on:
       setuptables:
         condition: service_completed_successfully

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -130,7 +130,7 @@ def test_fileondisk_save_failuremodes( diskfile ):
 
 def test_fileondisk_save_singlefile( diskfile, archive ):
     cfg = config.Config.get()
-    archivebase = f"{os.getenv('ARCHIVE_DIR')}/{cfg.value('archive.path_base')}"
+    archivebase = f"{os.getenv('SEECHANGE_TEST_ARCHIVE_DIR')}/{cfg.value('archive.path_base')}"
 
     diskfile.filepath = 'test_fileondisk_save.dat'
     data1 = numpy.random.rand( 32 ).tobytes()
@@ -256,7 +256,7 @@ def test_fileondisk_save_singlefile( diskfile, archive ):
 def test_fileondisk_save_multifile( diskfile, archive ):
     try:
         cfg = config.Config.get()
-        archivebase = f"{os.getenv('ARCHIVE_DIR')}/{cfg.value('archive.path_base')}"
+        archivebase = f"{os.getenv('SEECHANGE_TEST_ARCHIVE_DIR')}/{cfg.value('archive.path_base')}"
 
         diskfile.filepath = 'test_fileondisk_save'
         data1 = numpy.random.rand( 32 ).tobytes()

--- a/tests/seechange_config_test.yaml
+++ b/tests/seechange_config_test.yaml
@@ -1,15 +1,19 @@
 preloads:
   - ../default_config.yaml
+overrides:
+  - local_overrides.yaml
+augments:
+  - local_augments.yaml
 
 db:
   host: seechange_postgres
 
 archive:
-  url: http://archive:8080/
+  archive_url: http://archive:8080/
   verify_cert: false
   path_base: test/
-  read_dir: null
-  write_dir: null
+  local_read_dir: null
+  local_write_dir: null
   token: insecure
 
 subtraction:

--- a/tests/util/test_config.py
+++ b/tests/util/test_config.py
@@ -15,25 +15,20 @@ from util import config
 
 
 class TestConfig:
-    # Nominally, this tests should pass even if SEECHANGE_CONFIG is not None.  However, because there
-    # are autouse fixtures in ../conftest.py, one of the side effects is that the config default
-    # gets set.
-    @pytest.mark.skipif( os.getenv("SEECHANGE_CONFIG") is not None, reason="Clear SEECHANGE_CONFIG to test this" )
-    def test_no_default( self ):
-        assert config.Config._default == None
-
-    @pytest.mark.skipif( os.getenv("SEECHANGE_CONFIG") is None, reason="Set SEECHANGE_CONFIG to test this" )
-    def test_default_default( self ):
-        cfg = config.Config.get()
-        assert cfg._path == pathlib.Path( os.getenv("SEECHANGE_CONFIG") )
-
-    def test_set_default( self ):
-        cfg = config.Config.get( _rundir / 'test.yaml', setdefault=True )
-        assert config.Config._default == f'{ (_rundir / "test.yaml").resolve() }'
-
     @pytest.fixture(scope='class')
-    def cfg( self ):
-        return config.Config.get( _rundir / 'test.yaml', setdefault=True )
+    def cfg(self):
+        print('setting up a config object with a spoof yaml file just for testing the config mechanism. ')
+        return config.Config.get(_rundir / 'test.yaml', setdefault=True)
+
+    def test_default_default( self ):
+        # make sure that when we load a config without parameters,
+        # it uses the default config file
+        default_config_path = (_rundir.parent.parent / 'default_config.yaml').resolve()
+        assert config.Config._default_default == str(default_config_path)
+
+    def test_default( self, cfg ):
+        assert config.Config._default == str((_rundir / "test.yaml").resolve())
+        assert cfg._path == (_rundir / "test.yaml").resolve()
 
     def test_preload(self, cfg):
         assert cfg.value('preload1dict1.preload1_1val1') == '2_1val1'

--- a/util/config.py
+++ b/util/config.py
@@ -85,14 +85,14 @@ class Config:
 
     4. Change a config value with
 
-           confobj.set_or_append_value( fieldspec, value )
+           confobj.set_value( fieldspec, value )
 
        This only changes it for the running session, it does *not*
        affect the YAML files in storage.
 
     """
 
-    _default_default = os.getenv("SEECHANGE_CONFIG", None)
+    _default_default = str((pathlib.Path(__file__).parent.parent / "default_config.yaml").resolve())
 
     _default = None
     _configs = {}
@@ -104,7 +104,8 @@ class Config:
         Parameters
         ----------
         configfile : str or pathlib.Path, default None
-            If None, will set the config file to os.getenv("SEECHANGE_CONFIG")
+            If None, will set the config file to default_config.yaml in
+            the top level of the project.
 
         logger: logging object, default: getLogger("main")
         
@@ -316,8 +317,9 @@ class Config:
         augmentpath = pathlib.Path( augmentfile )
         if not augmentpath.is_absolute():
             augmentpath = ( self._path.parent / augmentfile ).resolve()
-        augment = Config( augmentpath, logger=self.logger, dirmap=dirmap )._data
-        self._data = Config._merge_trees( self._data, augment, augment=True )
+        if augmentpath.is_file():
+            augment = Config( augmentpath, logger=self.logger, dirmap=dirmap )._data
+            self._data = Config._merge_trees( self._data, augment, augment=True )
 
     def _override( self, overridefile, dirmap=dirmap ):
         """Read file (or path) overridefile and override config data.  Intended for internal use only.
@@ -340,10 +342,12 @@ class Config:
           recurse into the conflict rules.
         """
         overridepath = pathlib.Path( overridefile )
+
         if not overridepath.is_absolute():
             overridepath = ( self._path.parent / overridefile ).resolve()
-        override = Config( overridepath, logger=self.logger, dirmap=dirmap )._data
-        self._data = Config._merge_trees( self._data, override )
+        if overridepath.is_file():
+            override = Config( overridepath, logger=self.logger, dirmap=dirmap )._data
+            self._data = Config._merge_trees( self._data, override )
 
     def value( self, field, default=NoValue(), struct=None ):
         """Get a value from the config structure.
@@ -586,3 +590,8 @@ class Config:
             return newdict
         else:
             return copy.deepcopy( right )
+
+
+if __name__ == "__main__":
+    import os
+    conf = Config.get()


### PR DESCRIPTION
I want to make sure I can run the tests (and just regular operations) on my local machine. 
This requires that I install a bunch of things on my side, but to make this possible there are some changes needed: 
- Add default local_augments.yaml and local_overrides.yaml as optional files (that are not tracked) so users can define local modifications to the config. 
- Remove SEECHANGE_CONFIG environmental variable (always load the default config, except for tests...) and on top of that config you can define local changes. 
- For testing use the config file in the test folder. This happens on the first fixture in conftests.py
- Fix the archive configuration to run using local drive if needed. 

I also need to add a doc so that we can recreate this setup on a new machine if needed. 

There are probably more things. I will add them later. 
