### PR TITLE
Add columns to Exposure and Image models

### DIFF
--- a/models/exposure.py
+++ b/models/exposure.py
@@ -220,6 +220,43 @@ class Exposure(Base, FileOnDiskMixin, SpatiallyIndexed):
         doc='Name of the target object or field id. '
     )
 
+    sky_bkg = sa.Column(
+        sa.Float,
+        nullable=True,
+        doc="Sky background level in counts per second per pixel. "
+    )
+
+    sky_rms = sa.Column(
+        sa.Float,
+        nullable=True,
+        doc="Sky background RMS in counts per second per pixel. "
+    )
+
+    was_sky_sub = sa.Column(
+        sa.Boolean,
+        nullable=False,
+        default=False,
+        doc="Whether this exposure was sky subtracted. "
+    )
+
+    psf_fwhm = sa.Column(
+        sa.Float,
+        nullable=True,
+        doc="FWHM of the PSF in arcseconds. I.e., the seeing of this image. "
+    )
+
+    zero_point = sa.Column(
+        sa.Float,
+        nullable=True,
+        doc="Zero point of the image. "
+    )
+
+    lim_mag = sa.Column(
+        sa.Float,
+        nullable=True,
+        doc="Limiting magnitude of the image. "
+    )
+
     def __init__(self, *args, **kwargs):
         """
         Initialize the exposure object.


### PR DESCRIPTION
We clearly need a few searchable columns on Exposure and Image. 

There are a lot of open questions so I've decided to open a draft PR and have a discussion here. 

Some things I'm not sure about:
 - Image class should have similar columns to Exposure, but probably will have different values because these are sections of the main Exposure? 
 - Sky background mean/rms: should we do the mean of the sky? median? is rms a good measurement? 
 - PSF width (seeing) and zero point and limiting mag and sky background: all these measurements can be made downstream in the pipeline, and could each have multiple versions/provenances attached. If we want to use them as the value for each Image/Exposure we will have to decide which version to pick and when to update the numbers (e.g., when a new SExtractor parameter is used). 
 - What is the definition of limiting magnitude (e.g., 3 sigma? 5 sigma?) 
 - Column names: I tried to make them very clear but also short and not over-complicated. Opinions on naming are welcome as always. 
 - I am probably forgetting some more columns. Please suggest more. 
 - Should we index on all of these? If we envision using them as searchable columns, then probably indexing is the right thing to do. On the other hand, when did we ever need to filter a query based on sky rms? 