### PR TITLE
Name constraints

### DIFF
--- a/models/base.py
+++ b/models/base.py
@@ -984,7 +984,9 @@ class SpatiallyIndexed:
     def __table_args__(cls):
         tn = cls.__tablename__
         return (
-            sa.Index(f"{tn}_q3c_ang2ipix_idx", sa.func.q3c_ang2ipix(cls.ra, cls.dec)),
+            sa.Index( f"{tn}_q3c_ang2ipix_idx",
+                      sa.func.q3c_ang2ipix(cls.ra, cls.dec),
+                      name=f"ix_{tn}_q3c_radec"),
         )
 
     def calculate_coordinates(self):

--- a/models/base.py
+++ b/models/base.py
@@ -984,9 +984,7 @@ class SpatiallyIndexed:
     def __table_args__(cls):
         tn = cls.__tablename__
         return (
-            sa.Index( f"{tn}_q3c_ang2ipix_idx",
-                      sa.func.q3c_ang2ipix(cls.ra, cls.dec),
-                      name=f"ix_{tn}_q3c_radec"),
+            sa.Index(f"{tn}_q3c_ang2ipix_idx", sa.func.q3c_ang2ipix(cls.ra, cls.dec)),
         )
 
     def calculate_coordinates(self):

--- a/models/cutouts.py
+++ b/models/cutouts.py
@@ -33,7 +33,7 @@ class Cutouts(Base, FileOnDiskMixin, SpatiallyIndexed):
         self._format = cutouts_format_converter(value)
 
     source_list_id = sa.Column(
-        sa.ForeignKey('source_lists.id'),
+        sa.ForeignKey('source_lists.id', name='cutouts_source_list_id_fkey'),
         nullable=False,
         index=True,
         doc="ID of the source list this cutout is associated with. "
@@ -45,7 +45,7 @@ class Cutouts(Base, FileOnDiskMixin, SpatiallyIndexed):
     )
 
     new_image_id = sa.Column(
-        sa.ForeignKey('images.id'),
+        sa.ForeignKey('images.id', name='cutouts_new_image_id_fkey'),
         nullable=False,
         index=True,
         doc="ID of the new science image this cutout is associated with. "
@@ -58,7 +58,7 @@ class Cutouts(Base, FileOnDiskMixin, SpatiallyIndexed):
     )
 
     ref_image_id = sa.Column(
-        sa.ForeignKey('images.id'),
+        sa.ForeignKey('images.id', name='cutouts_ref_image_id_fkey'),
         nullable=False,
         index=True,
         doc="ID of the reference image this cutout is associated with. "
@@ -71,7 +71,7 @@ class Cutouts(Base, FileOnDiskMixin, SpatiallyIndexed):
     )
 
     sub_image_id = sa.Column(
-        sa.ForeignKey('images.id'),
+        sa.ForeignKey('images.id', name='cutouts_sub_image_id_fkey'),
         nullable=False,
         index=True,
         doc="ID of the subtraction image this cutout is associated with. "
@@ -96,7 +96,7 @@ class Cutouts(Base, FileOnDiskMixin, SpatiallyIndexed):
     )
 
     provenance_id = sa.Column(
-        sa.ForeignKey('provenances.id', ondelete="CASCADE"),
+        sa.ForeignKey('provenances.id', ondelete="CASCADE", name='cutouts_provenance_id_fkey'),
         nullable=False,
         index=True,
         doc=(

--- a/models/image.py
+++ b/models/image.py
@@ -33,8 +33,14 @@ import util.config as config
 image_source_self_association_table = sa.Table(
     'image_sources',
     Base.metadata,
-    sa.Column('source_id', sa.Integer, sa.ForeignKey('images.id', ondelete="CASCADE"), primary_key=True),
-    sa.Column('combined_id', sa.Integer, sa.ForeignKey('images.id', ondelete="CASCADE"), primary_key=True),
+    sa.Column('source_id',
+              sa.Integer,
+              sa.ForeignKey('images.id', ondelete="CASCADE", name='image_sources_source_id_fkey'),
+              primary_key=True),
+    sa.Column('combined_id',
+              sa.Integer,
+              sa.ForeignKey('images.id',ondelete="CASCADE", name='image_sources_combined_id_fkey'),
+              primary_key=True),
 )
 
 
@@ -64,7 +70,7 @@ class Image(Base, FileOnDiskMixin, SpatiallyIndexed, FourCorners):
         self._format = image_format_converter(value)
 
     exposure_id = sa.Column(
-        sa.ForeignKey('exposures.id', ondelete='SET NULL'),
+        sa.ForeignKey('exposures.id', ondelete='SET NULL', name='images_exposure_id_fkey'),
         nullable=True,
         index=True,
         doc=(
@@ -97,7 +103,7 @@ class Image(Base, FileOnDiskMixin, SpatiallyIndexed, FourCorners):
     )
 
     ref_image_id = sa.Column(
-        sa.ForeignKey('images.id', ondelete="CASCADE"),
+        sa.ForeignKey('images.id', ondelete="CASCADE", name='images_ref_image_id_fkey'),
         nullable=True,
         index=True,
         doc=(
@@ -119,7 +125,7 @@ class Image(Base, FileOnDiskMixin, SpatiallyIndexed, FourCorners):
     )
 
     new_image_id = sa.Column(
-        sa.ForeignKey('images.id', ondelete="CASCADE"),
+        sa.ForeignKey('images.id', ondelete="CASCADE", name='images_new_image_id_fkey'),
         nullable=True,
         index=True,
         doc=(
@@ -194,7 +200,7 @@ class Image(Base, FileOnDiskMixin, SpatiallyIndexed, FourCorners):
         self._type = image_type_converter(value)
 
     provenance_id = sa.Column(
-        sa.ForeignKey('provenances.id', ondelete="CASCADE"),
+        sa.ForeignKey('provenances.id', ondelete="CASCADE", name='images_provenance_id_fkey'),
         nullable=False,
         index=True,
         doc=(

--- a/models/measurements.py
+++ b/models/measurements.py
@@ -10,7 +10,7 @@ class Measurements(Base, SpatiallyIndexed):
     __tablename__ = 'measurements'
 
     cutouts_id = sa.Column(
-        sa.ForeignKey('cutouts.id'),
+        sa.ForeignKey('cutouts.id', name='measurements_cutouts_id_fkey'),
         nullable=False,
         index=True,
         doc="ID of the cutout this measurement is associated with. "
@@ -22,7 +22,7 @@ class Measurements(Base, SpatiallyIndexed):
     )
 
     provenance_id = sa.Column(
-        sa.ForeignKey('provenances.id', ondelete="CASCADE"),
+        sa.ForeignKey('provenances.id', ondelete="CASCADE", name='measurements_provenance_id_fkey'),
         nullable=False,
         index=True,
         doc="ID of the provenance of this measurement. "

--- a/models/provenance.py
+++ b/models/provenance.py
@@ -19,7 +19,10 @@ class CodeHash(Base):
 
     hash = sa.Column(sa.String, index=True, unique=True)
 
-    code_version_id = sa.Column(sa.Integer, sa.ForeignKey("code_versions.id", ondelete="CASCADE"))
+    code_version_id = sa.Column(sa.Integer,
+                                sa.ForeignKey("code_versions.id",
+                                              ondelete="CASCADE",
+                                              name='code_hashes_code_version_id_fkey'))
 
     code_version = relationship("CodeVersion", back_populates="code_hashes", lazy='selectin')
 
@@ -59,8 +62,14 @@ class CodeVersion(Base):
 provenance_self_association_table = sa.Table(
     'provenance_upstreams',
     Base.metadata,
-    sa.Column('upstream_id', sa.Integer, sa.ForeignKey('provenances.id', ondelete="CASCADE"), primary_key=True),
-    sa.Column('downstream_id', sa.Integer, sa.ForeignKey('provenances.id', ondelete="CASCADE"), primary_key=True),
+    sa.Column('upstream_id',
+              sa.Integer,
+              sa.ForeignKey('provenances.id', ondelete="CASCADE", name='provenance_upstreams_upstream_id_fkey'),
+              primary_key=True),
+    sa.Column('downstream_id',
+              sa.Integer,
+              sa.ForeignKey('provenances.id', ondelete="CASCADE", name='provenance_upstreams_downstream_id_fkey'),
+              primary_key=True),
 )
 
 
@@ -75,7 +84,7 @@ class Provenance(Base):
     )
 
     code_version_id = sa.Column(
-        sa.ForeignKey("code_versions.id", ondelete="CASCADE"),
+        sa.ForeignKey("code_versions.id", ondelete="CASCADE", name='provenances_code_version_id_fkey'),
         nullable=False,
         index=True,
         doc="ID of the code version the provenance is associated with. ",
@@ -143,7 +152,7 @@ class Provenance(Base):
 
     replaced_by = sa.Column(
         sa.Integer,
-        sa.ForeignKey("provenances.id", ondelete="SET NULL"),
+        sa.ForeignKey("provenances.id", ondelete="SET NULL", name='provenances_replaced_by_fkey'),
         nullable=True,
         doc="ID of the provenance that replaces this one. ",
     )

--- a/models/references.py
+++ b/models/references.py
@@ -13,7 +13,7 @@ class ReferenceEntry(Base):
     __tablename__ = 'reference_images'
 
     image_id = sa.Column(
-        sa.ForeignKey('images.id', ondelete='CASCADE'),
+        sa.ForeignKey('images.id', ondelete='CASCADE', name='reference_images_image_id_fkey'),
         nullable=False,
         index=True,
         doc="ID of the reference image this object is referring to. "

--- a/models/source_list.py
+++ b/models/source_list.py
@@ -48,7 +48,7 @@ class SourceList(Base, FileOnDiskMixin):
         self._format = source_list_format_converter(value)
 
     image_id = sa.Column(
-        sa.ForeignKey('images.id'),
+        sa.ForeignKey('images.id', name='source_lists_image_id_fkey'),
         nullable=False,
         index=True,
         doc="ID of the image this source list was generated from. "
@@ -82,7 +82,7 @@ class SourceList(Base, FileOnDiskMixin):
     )
 
     provenance_id = sa.Column(
-        sa.ForeignKey('provenances.id', ondelete="CASCADE"),
+        sa.ForeignKey('provenances.id', ondelete="CASCADE", name='source_lists_provenance_id_fkey'),
         nullable=False,
         index=True,
         doc=(

--- a/models/world_coordinates.py
+++ b/models/world_coordinates.py
@@ -9,7 +9,7 @@ class WorldCoordinates(Base):
     __tablename__ = 'world_coordinates'
 
     source_list_id = sa.Column(
-        sa.ForeignKey('source_lists.id'),
+        sa.ForeignKey('source_lists.id', name='world_coordinates_source_list_id_fkey'),
         nullable=False,
         index=True,
         doc="ID of the source list this world coordinate system is associated with. "
@@ -21,7 +21,7 @@ class WorldCoordinates(Base):
     )
 
     provenance_id = sa.Column(
-        sa.ForeignKey('provenances.id', ondelete="CASCADE"),
+        sa.ForeignKey('provenances.id', ondelete="CASCADE", name='world_coordinates_provenance_id_fkey'),
         nullable=False,
         index=True,
         doc=(

--- a/models/zero_point.py
+++ b/models/zero_point.py
@@ -9,7 +9,7 @@ class ZeroPoint(Base):
     __tablename__ = 'zero_points'
 
     source_list_id = sa.Column(
-        sa.ForeignKey('source_lists.id'),
+        sa.ForeignKey('source_lists.id', name='zero_points_source_list_id_fkey'),
         nullable=False,
         index=True,
         doc="ID of the source list this zero point is associated with. "
@@ -21,7 +21,7 @@ class ZeroPoint(Base):
     )
 
     provenance_id = sa.Column(
-        sa.ForeignKey('provenances.id', ondelete="CASCADE"),
+        sa.ForeignKey('provenances.id', ondelete="CASCADE", name='zero_points_provenance_id_fkey'),
         nullable=False,
         index=True,
         doc=(


### PR DESCRIPTION
This is basically a null change; it just explicitly adds names to the ForeignKey constraints.  The names I've added are the same as what was there already (automatic creation), so there's no database migration associated with this.

The reason for this is future-proofing.  If a future version of sqlalchemy changes the default naming scheme (which you wouldn't expect them to do, but you never know), this way we'll know what the names of the foreign keys are.  This is necessary if we need to explicitly refer to those foreign keys in a future alembic migration.