### PR TITLE
Split up tests

### DIFF
--- a/.github/workflows/run-improc-tests.yml
+++ b/.github/workflows/run-improc-tests.yml
@@ -1,4 +1,4 @@
-name: Run Model Tests
+name: Run Image Processing Tests
 
 on:
   push:
@@ -59,4 +59,4 @@ jobs:
 
       - name: run test
         run: |
-          TEST_SUBFOLDER=models docker compose run runtests
+          TEST_SUBFOLDER=improc docker compose run runtests

--- a/.github/workflows/run-model-tests.yml
+++ b/.github/workflows/run-model-tests.yml
@@ -1,0 +1,62 @@
+name: Run Python Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: run tests in docker image
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      COMPOSE_FILE: tests/docker-compose.yaml
+
+    steps:
+      - name: Dump docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v2
+
+      - name: checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: log into github container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: setup docker buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker-container
+
+      - name: bake
+        uses: docker/bake-action@v2.3.0
+        with:
+          workdir: tests
+          load: true
+          files: docker-compose.yaml
+          set: |
+            seechange_postgres.tags=ghcr.io/${{ github.repository_owner }}/seechange-postgres
+            seechange_postgres.cache-from=type=gha,scope=cached-seechange-postgres
+            seechange_postgres.cache-to=type=gha,scope=cached-seechange-postgres,mode=max
+            setuptables.tags=ghcr.io/${{ github.repository_owner }}/runtests
+            setuptables.cache-from=type=gha,scope=cached-seechange
+            setuptables.cache-to=type=gha,scope=cached-seechange,mode=max
+            runtests.tags=ghcr.io/${{ github.repository_owner }}/runtests
+            runtests.cache-from=type=gha,scope=cached-seechange
+            runtests.cache-to=type=gha,scope=cached-seechange,mode=max
+            shell.tags=ghcr.io/${{ github.repository_owner }}/runtests
+            shell.cache-from=type=gha,scope=cached-seechange
+            shell.cache-to=type=gha,scope=cached-seechange,mode=max
+
+      - name: run test
+        run: |
+          TEST_SUBFOLDER=models docker compose run runtests

--- a/.github/workflows/run-pipeline-tests.yml
+++ b/.github/workflows/run-pipeline-tests.yml
@@ -1,4 +1,4 @@
-name: Run Python Tests
+name: Run Pipeline Tests
 
 on:
   push:
@@ -59,4 +59,4 @@ jobs:
 
       - name: run test
         run: |
-          TEST_SUBFOLDER="" docker compose run runtests
+          TEST_SUBFOLDER=pipeline docker compose run runtests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -59,4 +59,4 @@ jobs:
 
       - name: run test
         run: |
-          docker compose run runtests
+          TEST_SUBFOLDER="" docker compose run runtests

--- a/.github/workflows/run-util-tests.yml
+++ b/.github/workflows/run-util-tests.yml
@@ -1,0 +1,62 @@
+name: Run Util Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: run tests in docker image
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      COMPOSE_FILE: tests/docker-compose.yaml
+
+    steps:
+      - name: Dump docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v2
+
+      - name: checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: log into github container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: setup docker buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker-container
+
+      - name: bake
+        uses: docker/bake-action@v2.3.0
+        with:
+          workdir: tests
+          load: true
+          files: docker-compose.yaml
+          set: |
+            seechange_postgres.tags=ghcr.io/${{ github.repository_owner }}/seechange-postgres
+            seechange_postgres.cache-from=type=gha,scope=cached-seechange-postgres
+            seechange_postgres.cache-to=type=gha,scope=cached-seechange-postgres,mode=max
+            setuptables.tags=ghcr.io/${{ github.repository_owner }}/runtests
+            setuptables.cache-from=type=gha,scope=cached-seechange
+            setuptables.cache-to=type=gha,scope=cached-seechange,mode=max
+            runtests.tags=ghcr.io/${{ github.repository_owner }}/runtests
+            runtests.cache-from=type=gha,scope=cached-seechange
+            runtests.cache-to=type=gha,scope=cached-seechange,mode=max
+            shell.tags=ghcr.io/${{ github.repository_owner }}/runtests
+            shell.cache-from=type=gha,scope=cached-seechange
+            shell.cache-to=type=gha,scope=cached-seechange,mode=max
+
+      - name: run test
+        run: |
+          TEST_SUBFOLDER=util docker compose run runtests

--- a/models/decam.py
+++ b/models/decam.py
@@ -16,6 +16,8 @@ import pandas
 import astropy.time
 from astropy.io import fits
 
+import sqlalchemy as sa
+
 from models.base import _logger, SmartSession, FileOnDiskMixin
 from models.instrument import Instrument, InstrumentOrientation, SensorSection
 from models.image import Image
@@ -353,7 +355,7 @@ class DECam(Instrument):
 
         with SmartSession( session ) as dbsess:
             if calibtype in [ 'flat', 'fringe' ]:
-                dbtype = 'Fringe' if calibtype=='fringe' else 'SkyFlat'
+                dbtype = 'Fringe' if calibtype == 'fringe' else 'SkyFlat'
                 mjd = float( cfg.value( "DECam.calibfiles.mjd" ) )
                 image = Image( format='fits', type=dbtype, provenance=prov, instrument='DECam',
                                telescope='CTIO4m', filter=filter, section_id=section, filepath=str(filepath),
@@ -379,10 +381,14 @@ class DECam(Instrument):
                 dbsess.add( calfile )
                 dbsess.commit()
             else:
-                datafile = DataFile( filepath=str(filepath), provenance=prov )
-                datafile.save( str(fileabspath) )
-                datafile = datafile.recursive_merge( dbsess )
-                dbsess.add( datafile )
+                datafile = dbsess.scalars(sa.select(DataFile).where(DataFile.filepath == str(filepath))).first()
+                # TODO: what happens if the provenance doesn't match??
+
+                if datafile is None:
+                    datafile = DataFile( filepath=str(filepath), provenance=prov )
+                    datafile.save( str(fileabspath) )
+                    datafile = datafile.recursive_merge( dbsess )
+                    dbsess.add( datafile )
                 # Linearity file applies for all chips, so load the database accordingly
                 for ssec in self._chip_radec_off.keys():
                     calfile = CalibratorFile( type='Linearity',
@@ -390,7 +396,8 @@ class DECam(Instrument):
                                               flat_type=None,
                                               instrument='DECam',
                                               sensor_section=ssec,
-                                              datafile=datafile )
+                                              datafile=datafile
+                                              )
                     calfile = calfile.recursive_merge( dbsess )
                     dbsess.add( calfile )
                 dbsess.commit()

--- a/models/instrument.py
+++ b/models/instrument.py
@@ -1300,7 +1300,7 @@ class Instrument:
                     else:
                         if calibquery.count() > 1:
                             _logger.warning( f"Found {calibquery.count()} valid {calibtype}s for "
-                                             f"{instrument.name} {section}, randomly using one." )
+                                             f"{self.name} {section}, randomly using one." )
                         calib = calibquery.first()
                 finally:
                     # Make sure that the calibrator_files table gets

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -93,7 +93,7 @@ services:
         target: /archive_storage
     working_dir: /seechange
     user: ${USERID:-0}:${GROUPID:-0}
-    entrypoint: [ "pytest", "-v", "/seechange/tests/", ${TEST_SUBFOLDER:-""}]
+    entrypoint: [ "pytest", "-v", "/seechange/tests/", ${TEST_SUBFOLDER:-""}, ]
 
   shell:
     image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -93,7 +93,7 @@ services:
         target: /archive_storage
     working_dir: /seechange
     user: ${USERID:-0}:${GROUPID:-0}
-    entrypoint: [ "pytest", "-v", "/seechange/tests/", ]
+    entrypoint: [ "pytest", "-v", "/seechange/tests/", ${TEST_SUBFOLDER:-""}]
 
   shell:
     image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -93,7 +93,7 @@ services:
         target: /archive_storage
     working_dir: /seechange
     user: ${USERID:-0}:${GROUPID:-0}
-    entrypoint: [ "pytest", "-v", "/seechange/tests/${TEST_SUBFOLDER:-""}", ]
+    entrypoint: [ "pytest", "-v", "/seechange/tests", ]
 
   shell:
     image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -93,7 +93,7 @@ services:
         target: /archive_storage
     working_dir: /seechange
     user: ${USERID:-0}:${GROUPID:-0}
-    entrypoint: [ "pytest", "-v", "/seechange/tests/"${TEST_SUBFOLDER:-""}, ]
+    entrypoint: "pytest -v /seechange/tests/$${TEST_SUBFOLDER:-''}"]
 
   shell:
     image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -93,7 +93,7 @@ services:
         target: /archive_storage
     working_dir: /seechange
     user: ${USERID:-0}:${GROUPID:-0}
-    entrypoint: [ "pytest", "-v", "/seechange/tests/", ${TEST_SUBFOLDER:-""}, ]
+    entrypoint: [ "pytest", "-v", "/seechange/tests/", "${TEST_SUBFOLDER:-""}", ]
 
   shell:
     image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -95,6 +95,29 @@ services:
     user: ${USERID:-0}:${GROUPID:-0}
     entrypoint: "pytest -v /seechange/tests/$TEST_SUBFOLDER"
 
+  runalltests:
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange
+    build:
+      context: ../docker/application
+    environment:
+      SEECHANGE_CONFIG: /seechange/tests/seechange_config_test.yaml
+      SEECHANGE_TEST_ARCHIVE_DIR: /archive_storage/base
+    depends_on:
+      setuptables:
+        condition: service_completed_successfully
+      archive:
+        condition: service_healthy
+    volumes:
+      - type: bind
+        source: ..
+        target: /seechange
+      - type: volume
+        source: archive-storage
+        target: /archive_storage
+    working_dir: /seechange
+    user: ${USERID:-0}:${GROUPID:-0}
+    entrypoint: "pytest -v /seechange/tests"
+
   shell:
     image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange
     build:

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -93,7 +93,7 @@ services:
         target: /archive_storage
     working_dir: /seechange
     user: ${USERID:-0}:${GROUPID:-0}
-    entrypoint: "pytest -v /seechange/tests/$$TEST_SUBFOLDER"
+    entrypoint: "pytest -v /seechange/tests/$TEST_SUBFOLDER"
 
   shell:
     image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -93,7 +93,7 @@ services:
         target: /archive_storage
     working_dir: /seechange
     user: ${USERID:-0}:${GROUPID:-0}
-    entrypoint: "pytest -v /seechange/tests/$${TEST_SUBFOLDER:-''}"
+    entrypoint: 'pytest -v /seechange/tests/$${TEST_SUBFOLDER:-""}'
 
   shell:
     image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -93,7 +93,7 @@ services:
         target: /archive_storage
     working_dir: /seechange
     user: ${USERID:-0}:${GROUPID:-0}
-    entrypoint: [ "pytest", "-v", "/seechange/tests/models", ]
+    entrypoint: [ "pytest", "-v", "/seechange/tests/"${TEST_SUBFOLDER:-""}, ]
 
   shell:
     image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -93,7 +93,7 @@ services:
         target: /archive_storage
     working_dir: /seechange
     user: ${USERID:-0}:${GROUPID:-0}
-    entrypoint: [ "pytest", "-v", "/seechange/tests", ]
+    entrypoint: [ "pytest", "-v", "/seechange/tests/models", ]
 
   shell:
     image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -93,7 +93,7 @@ services:
         target: /archive_storage
     working_dir: /seechange
     user: ${USERID:-0}:${GROUPID:-0}
-    entrypoint: [ "pytest", "-v", "/seechange/tests/", "${TEST_SUBFOLDER:-""}", ]
+    entrypoint: [ "pytest", "-v", "/seechange/tests/${TEST_SUBFOLDER:-""}", ]
 
   shell:
     image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -93,7 +93,7 @@ services:
         target: /archive_storage
     working_dir: /seechange
     user: ${USERID:-0}:${GROUPID:-0}
-    entrypoint: "pytest -v /seechange/tests/$${TEST_SUBFOLDER:-''}"]
+    entrypoint: "pytest -v /seechange/tests/$${TEST_SUBFOLDER:-''}"
 
   shell:
     image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -93,7 +93,7 @@ services:
         target: /archive_storage
     working_dir: /seechange
     user: ${USERID:-0}:${GROUPID:-0}
-    entrypoint: 'pytest -v /seechange/tests/$${TEST_SUBFOLDER:-""}'
+    entrypoint: "pytest -v /seechange/tests/$$TEST_SUBFOLDER"
 
   shell:
     image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange


### PR DESCRIPTION
I want the tests in each subfolder (currently, `models`, `pipeline` and `improc`) to run as separate workflows. 
Parallelizing the workflows will make our GA tests run faster.  