### PR TITLE
Add a __del__ method to FileOnDiskMixin

### DIFF
--- a/improc/alignment.py
+++ b/improc/alignment.py
@@ -98,17 +98,6 @@ class ParsImageAligner(Parameters):
 
 
 class ImageAligner:
-    temp_images = []
-
-    @classmethod
-    def cleanup_temp_images( cls ):
-        for im in cls.temp_images:
-            im.remove_data_from_disk()
-            for file in im.get_fullpath(as_list=True):
-                if file is not None and os.path.isfile( file ):
-                    raise RuntimeError( f'Failed to clean up {file}' )
-
-        cls.temp_images = []
 
     def __init__( self, **kwargs ):
         self.pars = ParsImageAligner( **kwargs )

--- a/models/image.py
+++ b/models/image.py
@@ -987,10 +987,6 @@ class Image(Base, AutoIDMixin, FileOnDiskMixin, SpatiallyIndexed, FourCorners, H
         The index to which the images are aligned is given by the "to_index" key in the
         "alignment" dictionary in the parameters of the image provenance; the value can
         be "first" or "last".
-
-        The resulting images are saved in _aligned_images, which are not saved
-        to the database. Note that each aligned image is also referred to by
-        a global variable under the ImageAligner.temp_images list.
         """
         from improc.alignment import ImageAligner  # avoid circular import
         if self.provenance is None or self.provenance.parameters is None:
@@ -1026,7 +1022,6 @@ class Image(Base, AutoIDMixin, FileOnDiskMixin, SpatiallyIndexed, FourCorners, H
         for i, image in enumerate(self.upstream_images):
             new_image = self._aligner.run(image, alignment_target)
             aligned.append(new_image)
-            ImageAligner.temp_images.append(new_image)  # keep track of all these images for cleanup purposes
 
         self._aligned_images = aligned
 

--- a/tests/fixtures/decam.py
+++ b/tests/fixtures/decam.py
@@ -288,8 +288,6 @@ def decam_datastore(
         if obj is not None and hasattr(obj, 'delete_from_disk_and_database'):
             obj.delete_from_disk_and_database(archive=True)
 
-    ImageAligner.cleanup_temp_images()
-
 
 @pytest.fixture
 def decam_processed_image(decam_datastore):
@@ -412,8 +410,6 @@ def decam_ref_datastore( code_version, download_url, decam_cache_dir, data_dir, 
     for obj in delete_list:
         if obj is not None and hasattr(obj, 'delete_from_disk_and_database'):
             obj.delete_from_disk_and_database(archive=True)
-
-    ImageAligner.cleanup_temp_images()
 
 
 @pytest.fixture

--- a/tests/improc/test_alignment.py
+++ b/tests/improc/test_alignment.py
@@ -113,7 +113,6 @@ def test_alignment_in_image( ptf_reference_images, code_version ):
                 check_aligned(image, ref)
 
     finally:
-        ImageAligner.cleanup_temp_images()
         for im in new_image.aligned_images:
             im.delete_from_disk_and_database()
         new_image.delete_from_disk_and_database(remove_downstream_data=True)


### PR DESCRIPTION
This cleans up un-committed files (if they don't have a primary key `id` set). 
This prevents orphan files of objects that were created and for some reason saved to disk / archive, but were never persisted. 

With this we can also remove the `ImageAlignment.temp_images` list that was used to help prevent build up of temporary aligned images and their associated files. 