### PR TITLE
Zogy improc memory fix

### DIFF
--- a/improc/zogy.py
+++ b/improc/zogy.py
@@ -134,7 +134,7 @@ def zogy_subtract(image_ref, image_new, psf_ref, psf_new, noise_ref, noise_new, 
     Pr = pad_to_shape(psf_ref, R.shape)
 
     # make sure all masked pixels in one image are masked in the other
-    nan_mask = np.isnan(R) | np.isnan(N) # TODO del
+    nan_mask = np.isnan(R) | np.isnan(N)
     if np.sum(~nan_mask) == 0:
         raise ValueError("All pixels are masked or no overlap between images.")
 
@@ -157,17 +157,17 @@ def zogy_subtract(image_ref, image_new, psf_ref, psf_new, noise_ref, noise_new, 
     F_n = flux_new
 
     # Fourier transform the images and the PSFs
-    R_f = np.fft.fft2(R) # TODO del big arr item=16
-    N_f = np.fft.fft2(N) # TODO del big arr item=16
-    P_r_f = np.fft.fft2(Pr) # TODO del big arr item=16
+    R_f = np.fft.fft2(R)
+    N_f = np.fft.fft2(N)
+    P_r_f = np.fft.fft2(Pr)
     Pr = None; del Pr
-    P_n_f = np.fft.fft2(Pn) # TODO del big arr item=16
+    P_n_f = np.fft.fft2(Pn)
     Pn = None; del Pn
-    P_r_f_abs2 = np.abs(P_r_f) ** 2 # TODO del normal arr
-    P_n_f_abs2 = np.abs(P_n_f) ** 2 # TODO del normal arr
+    P_r_f_abs2 = np.abs(P_r_f) ** 2
+    P_n_f_abs2 = np.abs(P_n_f) ** 2
 
     # now start calculating the main results, equations 12-16 from the paper:
-    F_D = F_r * F_n / np.sqrt(sigma_n ** 2 * F_r ** 2 + sigma_r ** 2 * F_n ** 2)  # eq 15 
+    F_D = F_r * F_n / np.sqrt(sigma_n ** 2 * F_r ** 2 + sigma_r ** 2 * F_n ** 2)  # eq 15
     denominator = sigma_n ** 2 * F_r ** 2 * P_r_f_abs2 + sigma_r ** 2 * F_n ** 2 * P_n_f_abs2  # eq 12's denominator
     # this can happen with certain rounding errors in the PSFs, but the numerator will also be zero, so it is ok:
     denominator[denominator == 0] = 1.0
@@ -222,7 +222,7 @@ def zogy_subtract(image_ref, image_new, psf_ref, psf_new, noise_ref, noise_new, 
     k_r_f = F_r * F_n ** 2 * np.conj(P_r_f) * P_n_f_abs2 / denominator
     P_r_f = None; del P_r_f
     k_r = np.real(np.fft.ifft2(k_r_f))
-    k_r2 = np.real(np.fft.ifft2(k_r_f)) ** 2
+    k_r2 = k_r ** 2
     k_r2_f = np.fft.fft2(k_r2)
     k_r = None; del k_r
     k_r2 = None; del k_r2
@@ -258,7 +258,6 @@ def zogy_subtract(image_ref, image_new, psf_ref, psf_new, noise_ref, noise_new, 
         V_S_n_ast = dx ** 2 * dS_n_dx ** 2 + dy ** 2 * dS_n_dy ** 2
 
         S_r = np.real(np.fft.ifft2(k_r_f * R_f))
-        
         dS_r_dy = S_r - np.roll(S_r, 1, axis=0)  # calculate the gradients
         dS_r_dx = S_r - np.roll(S_r, 1, axis=1)  # calculate the gradients
         V_S_r_ast = dx ** 2 * dS_r_dx ** 2 + dy ** 2 * dS_r_dy ** 2
@@ -266,9 +265,9 @@ def zogy_subtract(image_ref, image_new, psf_ref, psf_new, noise_ref, noise_new, 
         V_ast = V_S_r_ast + V_S_n_ast
     else:
         V_ast = 0
+        
     R_f = None; del R_f
     N_f = None; del N_f
-
     k_n_f = None; del k_n_f
     k_r_f = None; del k_r_f
 
@@ -282,7 +281,6 @@ def zogy_subtract(image_ref, image_new, psf_ref, psf_new, noise_ref, noise_new, 
     S_corr = S / V_S_sqrt
     Z_corr = Z / V_S
     V_S = None; del V_S
-    
 
     # PSF photometry part:
     # Eqs. 41-43 from paper
@@ -297,7 +295,6 @@ def zogy_subtract(image_ref, image_new, psf_ref, psf_new, noise_ref, noise_new, 
     alpha = S / F_S
     V_S_sqrt[zero_mask] = 0  # should we replace this with NaNs?
     alpha_std = V_S_sqrt / F_S
-    (proc, origmem, mem_array)
     V_S_sqrt = None; del V_S_sqrt
 
     # rename the outputs and fftshift back

--- a/improc/zogy.py
+++ b/improc/zogy.py
@@ -182,8 +182,8 @@ def zogy_subtract(image_ref, image_new, psf_ref, psf_new, noise_ref, noise_new, 
     Z2_f = Z0 * np.fft.fftshift(k2) / m2  # make sure the zero frequency is in the corner
 
     # transform the subtracted image (and PSF, score) back to real space
-    D = np.real(np.fft.ifft2(D_f))
-    P_D = np.real(np.fft.ifft2(P_D_f))
+    # D = np.real(np.fft.ifft2(D_f))
+    # P_D = np.real(np.fft.ifft2(P_D_f))
     S = np.real(np.fft.ifft2(S_f))
     Z = np.imag(np.fft.ifft2(Z1_f)) ** 2 + np.imag(np.fft.ifft2(Z2_f)) ** 2  # this is Z^2 but we'll call it Z for short
 
@@ -236,8 +236,8 @@ def zogy_subtract(image_ref, image_new, psf_ref, psf_new, noise_ref, noise_new, 
     zero_mask = V_S == 0  # get rid of zeros
     V_S_sqrt = np.sqrt(V_S, where=~zero_mask)
     V_S_sqrt[zero_mask] = 1
-    S_corr = S / V_S_sqrt
-    Z_corr = Z / V_S
+    # S_corr = S / V_S_sqrt
+    # Z_corr = Z / V_S
 
     # PSF photometry part:
     # Eqs. 41-43 from paper
@@ -251,16 +251,16 @@ def zogy_subtract(image_ref, image_new, psf_ref, psf_new, noise_ref, noise_new, 
     alpha_std = V_S_sqrt / F_S
 
     # rename the outputs and fftshift back
-    sub_image = np.fft.fftshift(D)
-    sub_psf = np.fft.fftshift(P_D)
+    sub_image = np.fft.fftshift(np.real(np.fft.ifft2(D_f)))
+    sub_psf = np.fft.fftshift(np.real(np.fft.ifft2(P_D_f)))
     score = np.fft.fftshift(S)
-    score_corr = np.fft.fftshift(S_corr)
+    score_corr = np.fft.fftshift(S / V_S_sqrt)
     alpha = np.fft.fftshift(alpha)
     alpha_std = np.fft.fftshift(alpha_std)
 
     translient = np.fft.fftshift(Z)
     translient_sigma = norm.isf(chi2.sf(translient, df=2))
-    translient_corr = np.fft.fftshift(Z_corr)
+    translient_corr = np.fft.fftshift(Z / V_S)
     translient_corr_sigma = norm.isf(chi2.sf(translient_corr, df=2))
 
     return dict(

--- a/improc/zogy.py
+++ b/improc/zogy.py
@@ -3,6 +3,7 @@
 # also got some useful ideas from the implementation here: https://github.com/pmvreeswijk/ZOGY/blob/main/zogy.py#L15721
 
 import numpy as np
+import psutil
 import scipy
 from scipy.stats.distributions import norm, chi2
 
@@ -113,6 +114,15 @@ def zogy_subtract(image_ref, image_new, psf_ref, psf_new, noise_ref, noise_new, 
             The corrected translient score, converted to S/N units assuming a chi2 distribution.
 
     """
+
+    proc = psutil.Process()
+    origmem = proc.memory_info()
+    mem_array = []
+    # array([0.        , 0.87232512, 1.87921203, 3.89255168, 4.29509427, 4.56368128, 4.85743002])
+    freemem = proc.memory_info()
+    mem_array.append(freemem.rss - origmem.rss)
+    # breakpoint()
+
     if dy is None:
         dy = dx  # assume equal astrometric noise if only dx is given
 
@@ -262,6 +272,11 @@ def zogy_subtract(image_ref, image_new, psf_ref, psf_new, noise_ref, noise_new, 
     translient_sigma = norm.isf(chi2.sf(translient, df=2))
     translient_corr = np.fft.fftshift(Z / V_S)
     translient_corr_sigma = norm.isf(chi2.sf(translient_corr, df=2))
+
+    freemem = proc.memory_info()
+    mem_array.append(freemem.rss - origmem.rss)
+    breakpoint()
+    # 5.6G before, peak was just before this
 
     return dict(
         sub_image=sub_image,

--- a/improc/zogy.py
+++ b/improc/zogy.py
@@ -149,8 +149,8 @@ def zogy_subtract(image_ref, image_new, psf_ref, psf_new, noise_ref, noise_new, 
         raise ValueError("noise_new must have the same shape as the new image.")
 
     # get the representative noise values
-    sigma_r = np.median(noise_ref[~nan_mask]) if isinstance(noise_ref, np.ndarray) else noise_ref 
-    sigma_n = np.median(noise_new[~nan_mask]) if isinstance(noise_new, np.ndarray) else noise_new 
+    sigma_r = np.median(noise_ref[~nan_mask]) if isinstance(noise_ref, np.ndarray) else noise_ref
+    sigma_n = np.median(noise_new[~nan_mask]) if isinstance(noise_new, np.ndarray) else noise_new
     nan_mask = None; del nan_mask # This fails to save memory for some reason
     # these are just shorthands for the flux normalization of each image
     F_r = flux_ref


### PR DESCRIPTION
I noticed in a regular run of the pipeline that the method `zogy_subtract` used an enormous amount of memory (about 4.8g during the method) due to creating a large amount of numpy arrays and leaving them around until the method ran out of scope.

Most arrays created were size 8e6 items and of itemsize 8 or 16 bytes (split about half and half), so each array was of size 65/130 e6 bytes.

With this rough proposed fix I change nothing in the logic of the method, but simply delete each array when it is no longer needed.

The result is that in a single run of the method it goes from using 4.8g to peaking around 2.2g, and in a test that runs the full pipeline once, in linux's top the pytest memory usage peaks roughly around 2.5g instead of 5.8.

