### PR TITLE
Import Object whenever importing Measurements

### DIFF
--- a/models/cutouts.py
+++ b/models/cutouts.py
@@ -661,6 +661,7 @@ class Cutouts(Base, AutoIDMixin, FileOnDiskMixin, SpatiallyIndexed, HasBitFlagBa
     def get_downstreams(self, session=None):
         """Get the downstream Measurements that were made from this Cutouts. """
         from models.measurements import Measurements
+        from models.objects import Object
         with SmartSession(session) as session:
             return session.scalars(sa.select(Measurements).where(Measurements.cutouts_id == self.id)).all()
 

--- a/pipeline/data_store.py
+++ b/pipeline/data_store.py
@@ -13,6 +13,7 @@ from models.zero_point import ZeroPoint
 from models.reference import Reference
 from models.cutouts import Cutouts
 from models.measurements import Measurements
+from models.objects import Object
 
 
 UPSTREAM_NAMES = {

--- a/pipeline/measuring.py
+++ b/pipeline/measuring.py
@@ -9,6 +9,7 @@ from util.util import parse_session
 from models.base import _logger
 from models.cutouts import Cutouts
 from models.measurements import Measurements
+from models.object import Object
 from models.enums_and_bitflags import BitFlagConverter
 
 from improc.photometry import iterative_photometry

--- a/pipeline/measuring.py
+++ b/pipeline/measuring.py
@@ -9,7 +9,7 @@ from util.util import parse_session
 from models.base import _logger
 from models.cutouts import Cutouts
 from models.measurements import Measurements
-from models.object import Object
+from models.objects import Object
 from models.enums_and_bitflags import BitFlagConverter
 
 from improc.photometry import iterative_photometry


### PR DESCRIPTION
See Issue #265

I suspect this never showed up in tests because everything in tests that imported measurements also imported objects.  I ran across this working on the stress test.  I didn't import either, but then had a crash when there was an sqlalchemy query somewhere in there because a sqlalchemy construct in Measurements referenced Object, but Object had never been imported.
