### PR TITLE
Replace session close with transaction close

### DIFF
--- a/models/instrument.py
+++ b/models/instrument.py
@@ -599,8 +599,6 @@ class Instrument:
                     sec.validity_end = validity_end
                 session.add(sec)
 
-            session.commit()
-
     def get_property(self, section_id, prop):
         """
         Get the value of a property for a given section of the instrument.
@@ -1366,7 +1364,7 @@ class Instrument:
 
         Will load it into the database as both an Image and a Calibrator
         Image; may also load other default calibrator images if they
-        come as a pack. WILL CALL session.commit()!
+        come as a pack.
 
         Should not be called from outside Instrument; instead, use
         preprocessing_calibrator_files.  _get_default_calibrator method
@@ -1407,13 +1405,10 @@ class Instrument:
     def preprocessing_calibrator_files( self, calibset, flattype, section, filter, mjd, nofetch=False, session=None ):
         """Get a dictionary of calibrator images/datafiles for a given mjd and sensor section.
 
-        MIGHT call session.commit(); see below.
-
         Instruments *may* need to override this.
 
         If a calibrator file doesn't exist for calibset 'default', will
-        call the instrument's _get_default_calibrator, which will call
-        session.commit().
+        call the instrument's _get_default_calibrator.
 
         If a calibrator file isn't found (potentially after calling the
         instrument's _get_default_calibrator), then the _isimage and

--- a/models/measurements.py
+++ b/models/measurements.py
@@ -398,7 +398,7 @@ class Measurements(Base, AutoIDMixin, SpatiallyIndexed):
         return []
 
     @classmethod
-    def delete_list(cls, measurements_list, session=None, commit=True):
+    def delete_list(cls, measurements_list, session=None):
         """
         Remove a list of Measurements objects from the database.
 
@@ -407,18 +407,9 @@ class Measurements(Base, AutoIDMixin, SpatiallyIndexed):
         measurements_list: list of Measurements
             The list of Measurements objects to remove.
         session: Session, optional
-            The database session to use. If not given, will create a new session.
-        commit: bool
-            If True, will commit the changes to the database.
-            If False, will not commit the changes to the database.
-            If session is not given, commit must be True.
+            The database session to use. If not given, will open a connection
+            and close it by calling commit (or rollback) at the end of the function.
         """
-        if session is None and not commit:
-            raise ValueError('If session is not given, commit must be True.')
-
         with SmartSession(session) as session:
             for m in measurements_list:
-                m.delete_from_database(session=session, commit=False)
-            if commit:
-                session.commit()
-
+                m.delete_from_database(session=session)

--- a/models/provenance.py
+++ b/models/provenance.py
@@ -239,7 +239,7 @@ class Provenance(Base):
         if not isinstance(code_version, CodeVersion):
             raise ValueError(f'Code version must be a models.CodeVersion. Got {type(code_version)}.')
         else:
-            self.code_version = code_version
+            self.code_version_id = code_version.id
 
         self.parameters = kwargs.get('parameters', {})
         upstreams = kwargs.get('upstreams', [])
@@ -266,7 +266,7 @@ class Provenance(Base):
             '<Provenance('
             f'id= {self.id[:6] if self.id else "<None>"}, '
             f'process="{self.process}", '
-            f'code_version="{self.code_version.id}", '
+            f'code_version="{self.code_version_id}", '
             f'parameters={self.parameters}, '
             f'upstreams={upstream_hashes})>'
         )
@@ -297,14 +297,14 @@ class Provenance(Base):
         """
         Update the id using the code_version, parameters and upstream_hashes.
         """
-        if self.process is None or self.parameters is None or self.code_version is None:
-            raise ValueError('Provenance must have process, code_version, and parameters defined. ')
+        if self.process is None or self.parameters is None or self.code_version_id is None:
+            raise ValueError('Provenance must have process, code_version_id, and parameters defined. ')
 
         superdict = dict(
             process=self.process,
             parameters=self.parameters,
             upstream_hashes=self.upstream_hashes,  # this list is ordered by upstream ID
-            code_version=self.code_version.id
+            code_version=self.code_version_id
         )
         json_string = json.dumps(superdict, sort_keys=True)
 
@@ -354,4 +354,5 @@ CodeVersion.provenances = relationship(
     cascade="save-update, merge, expunge, refresh-expire, delete, delete-orphan",
     foreign_keys="Provenance.code_version_id",
     passive_deletes=True,
+    lazy='selectin',
 )

--- a/pipeline/catalog_tools.py
+++ b/pipeline/catalog_tools.py
@@ -367,7 +367,6 @@ def fetch_gaia_dr3_excerpt( image, minstars=50, maxmags=22, magrange=None, sessi
                 if not os.path.isfile( catexp.get_fullpath() ):
                     _logger.info( f"CatalogExcerpt {catexp.id} has no file at {catexp.filepath}")
                     session.delete( catexp )
-                    session.commit()
                     catexp = None
                 else:
                     break
@@ -392,7 +391,6 @@ def fetch_gaia_dr3_excerpt( image, minstars=50, maxmags=22, magrange=None, sessi
                         session.add( catexp )  # add if it doesn't exist
                     else:
                         raise RuntimeError('CatalogExcerpt already exists in the database!')
-                    session.commit()
                     break
                 else:
                     catexp = None

--- a/pipeline/parameters.py
+++ b/pipeline/parameters.py
@@ -662,10 +662,11 @@ class Parameters:
             A dictionary of Provenance objects, from which the relevant
             upstream ids can be retrieved. If not given, will be filled
             automatically using the most up-to-date provenances.
-        session: sqlalchemy.orm.session.Session or SmartSession
+        session: sqlalchemy.orm.session.Session
             The database session to use to retrieve the provenances.
-            If not given, will open a new session and close it at
-            the end of the function.
+            If not given, will open a new connection on the session
+            and close it at the end of the function by calling commit
+            or rollback.
         """
         if prov_cache is None:
             prov_cache = {}
@@ -717,7 +718,6 @@ class Parameters:
             if existing_p is not None:
                 prov = existing_p
                 session.add(prov)
-                session.commit()  # make sure to add the new provenance
 
         return prov
 

--- a/tests/improc/test_alignment.py
+++ b/tests/improc/test_alignment.py
@@ -106,7 +106,6 @@ def test_alignment_in_image( ptf_reference_images, code_version ):
         # add new image to database
         with SmartSession() as session:
             new_image = session.merge(new_image)
-            session.commit()
 
         # should be able to recreate aligned images from scratch
         with SmartSession() as session:

--- a/tests/models/test_decam.py
+++ b/tests/models/test_decam.py
@@ -268,8 +268,8 @@ def test_decam_download_and_commit_exposure(
         with SmartSession() as session:
             exposures = session.query( Exposure ).filter( Exposure.id.in_( eids ) )
             for exposure in exposures:
-                exposure.delete_from_disk_and_database( session=session, commit=False )
-            session.commit()
+                exposure.delete_from_disk_and_database(session=session)
+
             # remove downloaded files from data_dir (a cached version should remain)
             if 'downloaded' in locals():
                 for d in downloaded:

--- a/tests/models/test_objects.py
+++ b/tests/models/test_objects.py
@@ -16,7 +16,7 @@ def test_object_creation():
     obj = Object(ra=1.0, dec=2.0, is_test=True)
     with SmartSession() as session:
         session.add(obj)
-        session.commit()
+        session.flush()
         assert obj.id is not None
         assert obj.name is not None
         assert re.match(r'\w+\d{4}\w+', obj.name)
@@ -91,7 +91,7 @@ def test_filtering_measurements_on_object(sim_lightcurves):
             m2 = session.merge(m2)
             new_measurements.append(m2)
 
-        session.commit()
+        session.flush()
         session.refresh(obj)
         all_ids = [m.id for m in new_measurements + measurements]
         all_ids.sort()

--- a/tests/models/test_source_list.py
+++ b/tests/models/test_source_list.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 import psutil
 import gc
 import pathlib
@@ -34,7 +33,7 @@ def test_source_list_bitflag(sim_sources):
         sim_sources.image.exposure.badness = 'Banding'
         sim_sources.image.exposure.update_downstream_badness(session)
         session.add(sim_sources.image)
-        session.commit()
+        session.flush()
 
         assert sim_sources.image.bitflag == 2 ** 1 + 2 ** 3
         assert sim_sources.image.badness == 'banding, saturation'
@@ -57,7 +56,7 @@ def test_source_list_bitflag(sim_sources):
         # add badness that works with source lists (e.g., cross-match failures)
         sim_sources.badness = 'few sources'
         session.add(sim_sources)
-        session.commit()
+        session.flush()
 
         assert sim_sources.bitflag == 2 ** 1 + 2 ** 3 + 2 ** 16
         assert sim_sources.badness == 'banding, saturation, few sources'
@@ -72,7 +71,7 @@ def test_source_list_bitflag(sim_sources):
         sim_sources.image.exposure.bitflag = 0
         sim_sources.image.exposure.update_downstream_badness(session)
         session.add(sim_sources.image)
-        session.commit()
+        session.flush()
 
         assert sim_sources.image.badness == 'saturation'
         assert sim_sources.badness == 'saturation, few sources'

--- a/tests/pipeline/test_extraction.py
+++ b/tests/pipeline/test_extraction.py
@@ -101,7 +101,7 @@ def test_sep_save_source_list(decam_small_image, provenance_base, extractor):
             sources = session.merge( sources )
             decam_small_image.save()  # pretend to save this file
             decam_small_image.exposure.save()
-            session.commit()
+            session.flush()
             image_id = decam_small_image.id
             sources_id = sources.id
 


### PR DESCRIPTION
This PR aims to solve some (if not most) of the problems we have with sqlalchemy. 

There are two main issues that cause most of our problems:
1) The objects are on the wrong session, on no session, or already added to this session, etc. 
2) The relationships (or sometimes regular attributes, e.g., after a rollback) are not accessible because the object is not connected to the database in some way. 

To solve (1) I have changed the definition of the SmartSession so that it now always loads the same session (as long as it is inside the same thread / process). This is done by using `scoped_session`. This has the drawback of making us have to keep that session open throughout the life of the app. 

To make sure we don't leave open connections, I've added code in the SmartSession that automatically calls `commit()` or `rollback()` at the end of the session's context. This releases the connection back to the database. We avoid having those connections stay open in a connection pull by setting `poolclass=sa.pool.NullPool`. Note that by having a single session throughout the app, we actually already reduce the number of possible DB connections, as each session can only hold one connection at a time. 

I've also set `autobegin=False` on the session, so that we don't accidentally start connections and leave them open. This brings us back to problem (2), where sometimes you need to access an attribute (usually a relationship) of the object but can't because it is not up to date with the DB and it is not connected to a session that can refresh it. 

While it is still possible to run into these problems, they will be much easier to solve: the object will always be connected to the same session, from the moment it is added or merged, and it will only ever raise a "session transaction was not begun" sort of error. No more needing to merge things into the active session to get them to work, simply wrap the code that needs access to the data with a SmartSession. 
Since the sessions are all the same, there is no danger in calling SmartSession deep inside an internal function that needs to load some data. The session will automatically begin a new transaction if one is not there, and it will shut it down at the end only if it was shut down when it started. 

It is still the responsibility of the developer to not wrap CPU intensive code within a SmartSession block where the connection is held open, but this was the case before, too.

A minor adjustment to the way we work is needed: we no longer call `session.commit()` directly, but assume it happens at the end of the SmartSession context. This also means that whenever that context goes out of scope, it will commit. To avoid actually modifying the database at the end of such a block, call `rollback()` instead. 