### PR TITLE
Conductor password file & through_step

### DIFF
--- a/default_config.yaml
+++ b/default_config.yaml
@@ -23,7 +23,7 @@ storage:
     # should Image object save the weights/flags/etc in a single file with the image data?
     single_file: false
     # The convention for building filenames for images
-    # Use any of the following: short_name, date, time, section_id, filter, ra, dec, prov_id
+    # Use any of the following: inst_name, date, time, section_id, filter, ra, dec, prov_id
     # Can also use section_id_int if the section_id is always an integer
     # Can also use ra_int and ra_frac to get the integer number before/after the decimal point
     # (the same can be done for dec). Also use ra_int_h to get the number in hours.
@@ -42,11 +42,11 @@ storage:
 #
 # Set to null if there is no archive; otherwise, a dict
 # Subfields:
-#   url: the URL of the archive server, or null if archive is on the filesystem
+#   archive_url: the URL of the archive server, or null if archive is on the filesystem
 #   verify_cert: boolean, should we verify the SSL cert of the archive server
 #   path_base: the base of the collection on the archive server (a string unique to this dataset)
-#   read_dir: the directory to read from if the archive is on the local filesystem, or null
-#   write_dir: the directory to write to if the archive is on the local filesystem, or null
+#   local_read_dir: the directory to read from if the archive is on the local filesystem, or null
+#   lcoal_write_dir: the directory to write to if the archive is on the local filesystem, or null
 
 archive: null
 

--- a/default_config.yaml
+++ b/default_config.yaml
@@ -58,7 +58,8 @@ archive: null
 conductor:
   conductor_url: unknown
   username: unknown
-  password: unknown
+  password: null
+  password_file: null
 
 
 # ======================================================================

--- a/models/exposure.py
+++ b/models/exposure.py
@@ -561,15 +561,20 @@ class Exposure(Base, UUIDMixin, FileOnDiskMixin, SpatiallyIndexed, HasBitFlagBad
 
         # Much code redundancy with Image.invent_filepath; move to a mixin?
 
+        inst_name = project = ''
+
         if self.provenance_id is None:
             raise ValueError("Cannot invent filepath for exposure without provenance.")
+        if self.instrument_object is not None:
+            inst_name = self.instrument_object.get_short_instrument_name()
+        if self.project is not None:
+            project = self.project
         prov_hash = self.provenance_id
 
         t = Time(self.mjd, format='mjd', scale='utc').datetime
         date = t.strftime('%Y%m%d')
         time = t.strftime('%H%M%S')
 
-        short_name = self.instrument_object.get_short_instrument_name()
         filter = self.instrument_object.get_short_filter_name(self.filter)
 
         ra = self.ra
@@ -584,14 +589,15 @@ class Exposure(Base, UUIDMixin, FileOnDiskMixin, SpatiallyIndexed, HasBitFlagBad
         dec_int_pm = f'p{dec_int:02d}' if dec_int >= 0 else f'm{dec_int:02d}'
         dec_frac = int(dec_frac)
 
-        default_convention = "{short_name}_{date}_{time}_{filter}_{prov_hash:.6s}"
+        default_convention = "{inst_name}_{date}_{time}_{filter}_{prov_hash:.6s}"
         cfg = Config.get()
         name_convention = cfg.value( 'storage.exposures.name_convention', default=None )
         if name_convention is None:
             name_convention = default_convention
 
         filepath = name_convention.format(
-            short_name=short_name,
+            inst_name=inst_name,
+            project=project,
             date=date,
             time=time,
             filter=filter,

--- a/models/image.py
+++ b/models/image.py
@@ -1068,7 +1068,7 @@ class Image(Base, UUIDMixin, FileOnDiskMixin, SpatiallyIndexed, FourCorners, Has
         upstream images.
 
         """
-        prov_hash = inst_name = im_type = date = time = filter = ra = dec = dec_int_pm = ''
+        prov_hash = inst_name = im_type = date = time = filter = ra = dec = dec_int_pm = project = ''
         section_id = section_id_int = ra_int = ra_int_h = ra_frac = dec_int = dec_frac = 0
 
         if self.provenance_id is not None:
@@ -1077,6 +1077,8 @@ class Image(Base, UUIDMixin, FileOnDiskMixin, SpatiallyIndexed, FourCorners, Has
             inst_name = self.instrument_object.get_short_instrument_name()
         if self.type is not None:
             im_type = self.type
+        if self.project is not None:
+            project = self.project
 
         if self.mjd is not None:
             t = Time(self.mjd, format='mjd', scale='utc').datetime
@@ -1116,6 +1118,7 @@ class Image(Base, UUIDMixin, FileOnDiskMixin, SpatiallyIndexed, FourCorners, Has
         filepath = name_convention.format(
             inst_name=inst_name,
             im_type=im_type,
+            project=project,
             date=date,
             time=time,
             filter=filter,

--- a/pipeline/top_level.py
+++ b/pipeline/top_level.py
@@ -92,7 +92,7 @@ class ParsPipeline(Parameters):
             None,
             ( None, str ),
             "Stop after this step.  None = run the whole pipeline.  String values can be "
-            "any of preprocessing, backgrounding, extraction, wcs, zp, subtraction, detection, cutting, measuring"
+            "any of preprocessing, backgrounding, extraction, wcs, zp, subtraction, detection, cutting, measuring",
             critical=False
         )
 

--- a/pipeline/top_level.py
+++ b/pipeline/top_level.py
@@ -87,6 +87,15 @@ class ParsPipeline(Parameters):
             critical=False
         )
 
+        self.through_step = self.add_par(
+            'through_step',
+            None,
+            ( None, str ),
+            "Stop after this step.  None = run the whole pipeline.  String values can be "
+            "any of preprocessing, backgrounding, extraction, wcs, zp, subtraction, detection, cutting, measuring"
+            critical=False
+        )
+
         self._enforce_no_new_attrs = True  # lock against new parameters
 
         self.override(kwargs)
@@ -284,12 +293,23 @@ class Pipeline:
             raise RuntimeError( "You have a persistent session in Pipeline.run; don't do that." )
 
         try:
+            stepstodo = [ 'preprocessing', 'backgrounding', 'extraction', 'wcs', 'zp', 'subtraction',
+                          'detection', 'cutting', 'measuring' ]
+            if self.pars.through_step is not None:
+                if self.pars.through_step not in stepsttodo:
+                    raise ValueError( f"Unknown through_step: \"{self.parse.through_step}\"" )
+                stepstodo = stepstodo[ :stepstodo.index(self.pars.through_step)+1 ]
+
             if ds.image is not None:
-                SCLogger.info(f"Pipeline starting for image {ds.image.id} ({ds.image.filepath})")
+                SCLogger.info(f"Pipeline starting for image {ds.image.id} ({ds.image.filepath}), "
+                              f"running through step {stepstodo[-1]}" )
             elif ds.exposure is not None:
-                SCLogger.info(f"Pipeline starting for exposure {ds.exposure.id} ({ds.exposure}) section {ds.section_id}")
+                SCLogger.info(f"Pipeline starting for exposure {ds.exposure.id} "
+                              f"({ds.exposure}) section {ds.section_id}, "
+                              f"running through step {stepstodo[-1]}" )
             else:
-                SCLogger.info(f"Pipeline starting with args {args}, kwargs {kwargs}")
+                SCLogger.info(f"Pipeline starting with args {args}, kwargs {kwargs}, "
+                              f"running through step {stepstodo[-1]}" )
 
             if env_as_bool('SEECHANGE_TRACEMALLOC'):
                 # ref: https://docs.python.org/3/library/tracemalloc.html#record-the-current-and-peak-size-of-all-traced-memory-blocks
@@ -300,30 +320,35 @@ class Pipeline:
                 ds.warnings_list = w  # appends warning to this list as it goes along
                 # run dark/flat preprocessing, cut out a specific section of the sensor
 
-                SCLogger.info(f"preprocessor")
-                ds = self.preprocessor.run(ds, session)
-                ds.update_report('preprocessing', session=None)
-                SCLogger.info(f"preprocessing complete: image id = {ds.image.id}, filepath={ds.image.filepath}")
+                if 'preprocessing' in stepstodo:
+                    SCLogger.info(f"preprocessor")
+                    ds = self.preprocessor.run(ds, session)
+                    ds.update_report('preprocessing', session=None)
+                    SCLogger.info(f"preprocessing complete: image id = {ds.image.id}, filepath={ds.image.filepath}")
 
                 # extract sources and make a SourceList and PSF from the image
-                SCLogger.info(f"extractor for image id {ds.image.id}")
-                ds = self.extractor.run(ds, session)
-                ds.update_report('extraction', session=None)
+                if 'extraction' in stepstodo:
+                    SCLogger.info(f"extractor for image id {ds.image.id}")
+                    ds = self.extractor.run(ds, session)
+                    ds.update_report('extraction', session=None)
 
                 # find the background for this image
-                SCLogger.info(f"backgrounder for image id {ds.image.id}")
-                ds = self.backgrounder.run(ds, session)
-                ds.update_report('extraction', session=None)
+                if 'backgrounding' in stepstodo:
+                    SCLogger.info(f"backgrounder for image id {ds.image.id}")
+                    ds = self.backgrounder.run(ds, session)
+                    ds.update_report('extraction', session=None)
 
                 # find astrometric solution, save WCS into Image object and FITS headers
-                SCLogger.info(f"astrometor for image id {ds.image.id}")
-                ds = self.astrometor.run(ds, session)
-                ds.update_report('extraction', session=None)
+                if 'wcs' in stepstodo:
+                    SCLogger.info(f"astrometor for image id {ds.image.id}")
+                    ds = self.astrometor.run(ds, session)
+                    ds.update_report('extraction', session=None)
 
                 # cross-match against photometric catalogs and get zero point, save into Image object and FITS headers
-                SCLogger.info(f"photometor for image id {ds.image.id}")
-                ds = self.photometor.run(ds, session)
-                ds.update_report('extraction', session=None)
+                if 'zp' in stepstodo:
+                    SCLogger.info(f"photometor for image id {ds.image.id}")
+                    ds = self.photometor.run(ds, session)
+                    ds.update_report('extraction', session=None)
 
                 if self.pars.save_before_subtraction:
                     t_start = time.perf_counter()
@@ -339,29 +364,33 @@ class Pipeline:
                     ds.runtimes['save_intermediate'] = time.perf_counter() - t_start
 
                 # fetch reference images and subtract them, save subtracted Image objects to DB and disk
-                SCLogger.info(f"subtractor for image id {ds.image.id}")
-                ds = self.subtractor.run(ds, session)
-                ds.update_report('subtraction', session=None)
+                if 'subtraction' in stepstodo:
+                    SCLogger.info(f"subtractor for image id {ds.image.id}")
+                    ds = self.subtractor.run(ds, session)
+                    ds.update_report('subtraction', session=None)
 
                 # find sources, generate a source list for detections
-                SCLogger.info(f"detector for image id {ds.image.id}")
-                ds = self.detector.run(ds, session)
-                ds.update_report('detection', session=None)
+                if 'detection' in stepstodo:
+                    SCLogger.info(f"detector for image id {ds.image.id}")
+                    ds = self.detector.run(ds, session)
+                    ds.update_report('detection', session=None)
 
                 # make cutouts of all the sources in the "detections" source list
-                SCLogger.info(f"cutter for image id {ds.image.id}")
-                ds = self.cutter.run(ds, session)
-                ds.update_report('cutting', session=None)
+                if 'cutting' in stepstodo:
+                    SCLogger.info(f"cutter for image id {ds.image.id}")
+                    ds = self.cutter.run(ds, session)
+                    ds.update_report('cutting', session=None)
 
                 # extract photometry and analytical cuts
-                SCLogger.info(f"measurer for image id {ds.image.id}")
-                ds = self.measurer.run(ds, session)
-                ds.update_report('measuring', session=None)
+                if 'measuring' in stepstodo:
+                    SCLogger.info(f"measurer for image id {ds.image.id}")
+                    ds = self.measurer.run(ds, session)
+                    ds.update_report('measuring', session=None)
 
                 # measure deep learning models on the cutouts/measurements
                 # TODO: add this...
 
-                if self.pars.save_at_finish:
+                if self.pars.save_at_finish and ( 'subtraction' in stepstodo ):
                     t_start = time.perf_counter()
                     try:
                         SCLogger.info(f"Saving final products for image id {ds.image.id}")

--- a/util/conductor_connector.py
+++ b/util/conductor_connector.py
@@ -13,7 +13,15 @@ class ConductorConnector:
         cfg = Config.get()
         self.url = url if url is not None else cfg.value( 'conductor.conductor_url' )
         self.username = username if username is not None else cfg.value( 'conductor.username' )
-        self.password = password if password is not None else cfg.value( 'conductor.password' )
+        if password is None:
+            password = cfg.value( 'conductor.password' )
+            if password is None:
+                if cfg.value( 'conductor.password_file' ) is None:
+                    raise ValueError( "ConductorConnector must have a password, either passed, or from "
+                                      "conductor.password or conductor.password_file configs" )
+                with open( cfg.value( "conductor.password_file" ) ) as ifp:
+                    password = ifp.readline().strip()
+        self.password = password
         self.verify = verify
         self.req = None
 


### PR DESCRIPTION
A couple of small modifications:

* Added the ability to read the conductor password from a file so it doesn't have to sit in the clear in a config file, but can go to a secrets directory
* Added the ability to `top_level.py` and `pipeline_exposure_launcher.py` to only process up through a specified step.  (I added this because I wanted to abuse `pipeline_exposure_launcher.py` as a bulk downloader, but it's a general good thing to have, at least for testing.)
* Couple of small fixes to `invent_filepath` in `image` and `exposure`, including in documentation.