### PR TITLE
Fix pipeline exposure launcher hang

### DIFF
--- a/docker/application/Dockerfile
+++ b/docker/application/Dockerfile
@@ -232,7 +232,7 @@ RUN source /venv/bin/activate \
 
 # Pytorch
 RUN source /venv/bin/activate \
-    && uv pip install torch==2.3.0+cpu --find-links https://download.pytorch.org/whl/torch_stable.html
+    && uv pip install torch==2.3.1+cpu --find-links https://download.pytorch.org/whl/torch_stable.html
 
 # RBbot
 # Remove the requirements.txt file because it will install

--- a/pipeline/exposure_processor.py
+++ b/pipeline/exposure_processor.py
@@ -3,7 +3,6 @@ import argparse
 import re
 import datetime
 import multiprocessing
-import multiprocessing.pool
 import logging
 import psutil
 
@@ -243,7 +242,7 @@ class ExposureProcessor:
 
             if self.numprocs > 1:
                 SCLogger.info( f"Creating pool of {self.numprocs} processes to do {len(chips)} chips" )
-                with multiprocessing.pool.Pool( self.numprocs, maxtasksperchild=1 ) as pool:
+                with multiprocessing.Pool( self.numprocs, maxtasksperchild=1 ) as pool:
                     for chip in chips:
                         pool.apply_async( self.processchip, ( chip, ), {}, self.collate )
 

--- a/pipeline/scoring.py
+++ b/pipeline/scoring.py
@@ -15,6 +15,10 @@ from models.enums_and_bitflags import DeepscoreAlgorithmConverter
 from util.config import Config
 from util.logger import SCLogger
 
+# Make sure that pytorch doesn't try to run lots of threads.
+# Run this at module import to make sure it always happens.
+torch.set_num_threads( 1 )
+
 
 class ParsScorer(Parameters):
     def __init__(self, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,8 +55,8 @@ from pipeline.data_store import DataStore, ProvenanceTree
 #   at the end of tests.  In general, we want this to be True, so we can make sure
 #   that our tests are properly cleaning up after themselves.  However, the errors
 #   from this can hide other errors and failures, so when debugging, set it to False.
-verify_archive_database_empty = True
-# verify_archive_database_empty = False
+# verify_archive_database_empty = True
+verify_archive_database_empty = False
 
 
 pytest_plugins = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,8 +55,8 @@ from pipeline.data_store import DataStore, ProvenanceTree
 #   at the end of tests.  In general, we want this to be True, so we can make sure
 #   that our tests are properly cleaning up after themselves.  However, the errors
 #   from this can hide other errors and failures, so when debugging, set it to False.
-# verify_archive_database_empty = True
-verify_archive_database_empty = False
+verify_archive_database_empty = True
+# verify_archive_database_empty = False
 
 
 pytest_plugins = [

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   make-archive-directories:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/upload-connector:${IMGTAG:-test20250623}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/upload-connector:${IMGTAG:-test20250624}
     build:
       context: ../extern/nersc-upload-connector
       args:
@@ -20,7 +20,7 @@ services:
     depends_on:
       make-archive-directories:
         condition: service_completed_successfully
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/upload-connector:${IMGTAG:-test20250623}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/upload-connector:${IMGTAG:-test20250624}
     build:
       context: ../extern/nersc-upload-connector
       args:
@@ -47,7 +47,7 @@ services:
     user: ${USERID:-0}:${GROUPID:-0}
 
   postgres:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/postgres:${IMGTAG:-test20250623}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/postgres:${IMGTAG:-test20250624}
     build:
       context: ../docker/postgres
     environment:
@@ -60,7 +60,7 @@ services:
       retries: 5
 
   setuptables:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange:${IMGTAG:-test20250623}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange:${IMGTAG:-test20250624}
     build:
       context: ../
       dockerfile: ./docker/application/Dockerfile
@@ -84,7 +84,7 @@ services:
         - "${MAILHOG_PORT:-8025}:8025"
 
   kafka-zookeeper:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/kafka:${IMGTAG:-test20250623}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/kafka:${IMGTAG:-test20250624}
     build:
       context: ../
       dockerfile: ./docker/test_kafka/Dockerfile
@@ -99,7 +99,7 @@ services:
     depends_on:
        kafka-zookeeper:
          condition: service_healthy
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/kafka:${IMGTAG:-test20250623}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/kafka:${IMGTAG:-test20250624}
     build:
       context: ../
       dockerfile: ./docker/test_kafka/Dockerfile
@@ -116,7 +116,7 @@ services:
         condition: service_completed_successfully
       make-archive-directories:
         condition: service_completed_successfully
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange-webap:${IMGTAG:-test20250623}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange-webap:${IMGTAG:-test20250624}
     build:
       context: ../
       dockerfile: ./docker/application/Dockerfile
@@ -139,7 +139,7 @@ services:
     entrypoint: [ "./run_webap.sh", "8081", "1" ]
 
   runtests:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange:${IMGTAG:-test20250623}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange:${IMGTAG:-test20250624}
     build:
       context: ../
       dockerfile: ./docker/application/Dockerfile
@@ -169,7 +169,7 @@ services:
     entrypoint: "pytest -v /seechange/$TEST_SUBFOLDER"
 
   runalltests:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange:${IMGTAG:-test20250623}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange:${IMGTAG:-test20250624}
     build:
       context: ../
       dockerfile: ./docker/application/Dockerfile
@@ -199,7 +199,7 @@ services:
     entrypoint: "pytest -v /seechange/tests"
 
   runruff:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange:${IMGTAG:-test20250623}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange:${IMGTAG:-test20250624}
     build:
       context: ../
       dockerfile: ./docker/application/Dockerfile
@@ -217,7 +217,7 @@ services:
 
 
   shell:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange:${IMGTAG:-test20250623}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-c3-time-domain}/seechange:${IMGTAG:-test20250624}
     build:
       context: ../
       dockerfile: ./docker/application/Dockerfile

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -427,7 +427,7 @@ def test_full_run_hotpants( decam_exposure, decam_reference, decam_default_calib
 
 
 
-@pytest.mark.skipif( not env_as_bool('RUN_SLOW_TESTS'), reason="Set RUN_SLOW_TEST=1 to run this test" )
+@pytest.mark.skipif( not env_as_bool('RUN_SLOW_TESTS'), reason="Set RUN_SLOW_TESTS=1 to run this test" )
 def test_data_flow(decam_exposure, decam_reference, decam_default_calibrators, pipeline_for_tests, archive):
     """Test that the pipeline runs end-to-end.
 

--- a/tests/pipeline/test_pipeline_exposure_launcher.py
+++ b/tests/pipeline/test_pipeline_exposure_launcher.py
@@ -112,6 +112,7 @@ def test_exposure_launcher_conductor_through_step( conductor_connector,
                                                    conductor_config_decam_pull_all_held,
                                                    decam_elais_e1_two_references,
                                                    user, admin_user ):
+    """Make sure ExposureLauncher stops where the conductor tells it to."""
     decam_exposure_name = 'c4d_230702_080904_ori.fits.fz'
 
     try:
@@ -151,6 +152,7 @@ def test_exposure_launcher_through_step( conductor_connector,
                                          conductor_config_decam_pull_all_held,
                                          decam_elais_e1_two_references,
                                          user, admin_user ):
+    """Make sure that if ExposureLauncher is told to stop at a step *earlier* than conductor, it stops there."""
     decam_exposure_name = 'c4d_230702_080904_ori.fits.fz'
 
     try:


### PR DESCRIPTION
The only real substantive change in this PR is the single line added to `scoring.py`.  It was causing tests to hang because we did stuff with pytorch in one process, and then tried to do more stuff with pytorch in a different process.  In fact, we also do that when running pipeline_exposure_launcher in production, but there the first process dies before the second process starts.  pytorch must be doing something strange with threading and so forth given the nature of the fix.

Some other changes here were put in for debugging, and left in because they will be useful for future debugging.  (In particular, all the changes to `updater.py` come from debugging problems that turned out not to be code problems, but the noirlab archive being offline.)